### PR TITLE
Bugfix/fix required mistune package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except ImportError:
     with open(readme_file) as f:
         readme = f.read()
 
-install_requires = ['mistune<=1', 'docutils']
+install_requires = ['mistune<1', 'docutils<1']
 test_requirements = ['pygments']
 if sys.version_info < (3, 3):
     test_requirements.append('mock')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except ImportError:
     with open(readme_file) as f:
         readme = f.read()
 
-install_requires = ['mistune', 'docutils']
+install_requires = ['mistune<=1', 'docutils']
 test_requirements = ['pygments']
 if sys.version_info < (3, 3):
     test_requirements.append('mock')


### PR DESCRIPTION
[Mistune](https://pypi.org/project/mistune/#history) released a new breaking version 2.0.0.

As the version of that required package is not fixed to a specific range or version, the latest available version of mistune is used. As that version is a breaking version the m2rr package is broken.

This fix sets a version below the first breaking version of `mistune` and `docutils`  to avoid this breaking change for m2rr